### PR TITLE
Add toggle for seconds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.timeplayed'
-version = '1.1.1'
+version = '1.2.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/timeplayed/TimePlayedConfig.java
+++ b/src/main/java/com/timeplayed/TimePlayedConfig.java
@@ -8,6 +8,14 @@ import java.awt.*;
 public interface TimePlayedConfig extends Config
 {
 	@ConfigItem(
+			keyName = "displays",
+			name = "Display seconds?",
+			description = "Check the box to display seconds.",
+			position = 1
+	)
+	default boolean displaySeconds() { return true; }
+
+	@ConfigItem(
 			keyName = "displayms",
 			name = "Display ms?",
 			description = "Check the box to display ms.",

--- a/src/main/java/com/timeplayed/TimePlayedOverlay.java
+++ b/src/main/java/com/timeplayed/TimePlayedOverlay.java
@@ -140,6 +140,9 @@ public class TimePlayedOverlay extends Overlay {
         } else {
             effectiveSec = seconds;
         }
+        if(config.displaySeconds() == false) {
+            return "";
+        }
         if (config.displayMs()) {
             int secs = effectiveSec / 10;
             int ms = effectiveSec % 10;


### PR DESCRIPTION
This PR adds a toggle for seconds.

I want to use this plugin to track playtime through the built in screenshot plugin but i find the seconds always counting a bit distracting.

<img width="455" height="666" alt="Screenshot_20251002_112102" src="https://github.com/user-attachments/assets/f010fb3d-d9ae-4eeb-a27e-94e356b113aa" />
